### PR TITLE
improve regex

### DIFF
--- a/FunctionExtractString.cs
+++ b/FunctionExtractString.cs
@@ -15,7 +15,7 @@ namespace CopyLine
         static string pattern2 = @"^(\(?[A-Za-z0-9]+[\)\.][ \t]+|[-\+\*][ \t]+)?(?<content>.+)";
 
         // remove last symbols
-        static string pattern3 = "[#+|○×][ \t]*";
+        static string pattern3 = "(#{2,}|[○×]).*";
 
         public static string GetExtractString(string str)
         {


### PR DESCRIPTION
- 選択肢に#が含まれている場合に削除される問題を解決
- 正答を示す#の個数を2個以上に変更
- 正答・誤答を示す ## ○☓ の後に文字があっても削除するように変更